### PR TITLE
fix uri - remove trailing /

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -4,7 +4,7 @@ namespace Allegro\REST;
 class Api extends Resource
 {
 
-    const API_URI = 'https://allegroapi.io/';
+    const API_URI = 'https://allegroapi.io';
 
     const TOKEN_URI = 'https://ssl.allegro.pl/auth/oauth/token';
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -20,9 +20,9 @@ class Resource
         return $this->parent->getApiKey();
     }
 
-    public function getUri()
+    public function getUri($subcommand = false)
     {
-        return $this->parent->getUri() . $this->id . '/';
+        return $this->parent->getUri(true) . $this->id . ($subcommand?'/':'');
     }
 
     public function commands()

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -22,7 +22,7 @@ class Resource
 
     public function getUri()
     {
-        return $this->parent->getUri() . $this->id . '/';
+        return $this->parent->getUri() . '/' . $this->id;
     }
 
     public function commands()

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -20,9 +20,9 @@ class Resource
         return $this->parent->getApiKey();
     }
 
-    public function getUri($subcommand = false)
+    public function getUri()
     {
-        return $this->parent->getUri(true) . $this->id . ($subcommand?'/':'');
+        return $this->parent->getUri() . $this->id . '/';
     }
 
     public function commands()

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -4,7 +4,7 @@ namespace Allegro\REST;
 class Sandbox extends Api
 {
 
-    const API_URI = 'https://sandbox.allegroapi.io/';
+    const API_URI = 'https://sandbox.allegroapi.io';
 
     const TOKEN_URI = 'https://ssl.allegro.pl.webapisandbox.pl/auth/oauth/token';
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -12,12 +12,12 @@ class ApiTest extends TestCase
     {
         $api = new Allegro\REST\Api('eggs', 'spam', 'ham', 'beans');
 
-        $this->assertEquals('https://allegroapi.io/', $api->getUri());
+        $this->assertEquals('https://allegroapi.io', $api->getUri());
 
-        $this->assertEquals('https://allegroapi.io/categories/',
+        $this->assertEquals('https://allegroapi.io/categories',
                             $api->categories->getUri());
 
-        $this->assertEquals('https://allegroapi.io/categories/12/',
+        $this->assertEquals('https://allegroapi.io/categories/12',
                             $api->categories(12)->getUri());
     }
 


### PR DESCRIPTION
Commands like $api->sale->{'user-ratings'}->get(array('user.id'=>'xxx','limit'=>100));
generated 404 url:
https://allegroapi.io/sale/user-ratings/?user.id=xxx&limit=100

should be:
https://allegroapi.io/sale/user-ratings?user.id=xxx&limit=100
