### PR TITLE
Allegro zmienia adres autoryzacji OAuth

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -6,9 +6,9 @@ class Api extends Resource
 
     const API_URI = 'https://allegroapi.io';
 
-    const TOKEN_URI = 'https://ssl.allegro.pl/auth/oauth/token';
+    const TOKEN_URI = 'https://allegro.pl/auth/oauth/token';
 
-    const AUTHORIZATION_URI = 'https://ssl.allegro.pl/auth/oauth/authorize';
+    const AUTHORIZATION_URI = 'https://allegro.pl/auth/oauth/authorize';
 
     /**
      * Api constructor.


### PR DESCRIPTION
w listopadzie 2017r. Allegro zmieniło adres autoryzacji OAuth z https://ssl.allegro.pl na https://allegro.pl.
Domena https://ssl.allegro.pl przestanie być wspierana 13 lutego 2018r.