### PR TITLE
Removing [0], [1] etc. from generated $uri after http_build_query() i…

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -59,6 +59,7 @@ class Resource
             $uri .= '?';
             $uri .= http_build_query($data);
         }
+        $uri = preg_replace('/(%5B\d+%5D)/', '', $uri); // Removing [0],[1]... generated for params with nested arrays
 
         return $this->sendApiRequest($uri, 'GET');
     }


### PR DESCRIPTION
When I want to send MULTI parameters, get method works wrong, because Allegro needs 
`"val=x&val=y&val=z" `
instead of 
`"val[0]=x&val[1]=y&val[2]=z"`
That's why we need to remove [\d+] from the query string.